### PR TITLE
Surface table functionality

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,4 @@
 [flake8]
 max-line-length=100
-ignore=E501,E231,W503
+ignore=E501,E231,W503,E203
 max-complexity=12

--- a/pyramm/__init__.py
+++ b/pyramm/__init__.py
@@ -1,6 +1,6 @@
 __version__ = "1.4"
 
-from pyramm import api  # noqa
+from . import api, ops  # noqa
 
 
 if __name__ == "__main__":

--- a/pyramm/ops/__init__.py
+++ b/pyramm/ops/__init__.py
@@ -1,0 +1,1 @@
+from . import top_surface  # noqa

--- a/pyramm/ops/top_surface.py
+++ b/pyramm/ops/top_surface.py
@@ -1,0 +1,129 @@
+from collections import defaultdict
+from typing import List
+import numpy as np
+import pandas as pd
+
+
+def build_top_surface(tables: List[pd.DataFrame]) -> pd.DataFrame:
+    """
+    Generate the top_surface table from several RAMM-style surface tables (with
+    overlapping surface records. If the table contains "full_width_flag" only full width
+    surface records are kept.
+
+    Surfaces are chosen in the following order: "surface_date", "start_m", "end_m". I.e.
+    Newer surfaces will take priority, followed by surfaces with a higher "start_m" (if
+    "surface_date" is the same), followed by surfaces with a higher "end_m" (if
+    "surface_date" and "start_m" are the same).
+
+    :param tables: List of DataFrames containing RAMM-style surface tables.
+    :return: new top_surface table with non-overlapping surface records.
+
+    """
+    tables = [_limit_to_full_width(tt) for tt in tables]
+    tables = [_reset_surface_table_index(tt) for tt in tables]
+
+    df = pd.concat(tables, ignore_index=True)
+    top_surface = pd.DataFrame()
+    for _, gg in df.groupby("road_id"):
+        gg = gg.sort_values(["surface_date", "start_m", "end_m"]).reset_index(drop=True)
+        gg.index += 1
+        grid = _surface_records_to_grid(gg)
+        surfaces = _extract_surface_records_from_grid(grid)
+        surfaces = surfaces.join(
+            gg[[cc for cc in gg.columns if cc not in ["start_m", "end_m"]]],
+            on="surface_id",
+        ).drop(columns="surface_id")
+        top_surface = pd.concat([top_surface, surfaces], ignore_index=True)
+    return top_surface.set_index(["road_id", "start_m", "end_m"]).sort_index()
+
+
+def append_surface_details_to_segments(df: pd.DataFrame, top_surface: pd.DataFrame):
+    """
+    Append surface details to each road segment.
+
+    :param df: Road segments. Must contain "road_id", "start_m", "end_m" columns.
+    :param top_surface: RAMM-style top_surface table with non-overlapping surface records.
+    :return: Road segments with surfaces details appended.
+
+    """
+    top_surface = _reset_surface_table_index(top_surface)
+    surface_columns = [
+        cc for cc in top_surface.columns if cc not in ["road_id", "start_m", "end_m"]
+    ]
+    df[surface_columns] = None
+
+    valid_surfaces = top_surface.loc[top_surface["road_id"].isin(df["road_id"])]
+    if len(valid_surfaces) == 0:
+        return df
+
+    for _, row in valid_surfaces.iterrows():
+        # Limit to the road segments that are fully within the surface section.
+        # Using less / greater than ensures that a join on the boundary results in
+        # the two straddling segments being excluded.
+        selected_segments = df.loc[
+            (df["road_id"] == row["road_id"])
+            & (df["start_m"] > row["start_m"])
+            & (df["end_m"] < row["end_m"])
+        ]
+
+        # Append the surface details to the appropriate rows:
+        for cc in surface_columns:
+            df.loc[selected_segments.index, cc] = row[cc]
+
+    df = _fix_na_columns(df)
+    return df
+
+
+def _limit_to_full_width(df):
+    if "full_width_flag" not in df.columns:
+        return df
+    return df.loc[df["full_width_flag"].str.lower() == "y"]
+
+
+def _reset_surface_table_index(df):
+    return df.reset_index() if df.index.names != [None] else df
+
+
+def _fix_na_columns(df):
+    for cc in df.columns:
+        fill_value = 0 if df[cc].dtype.type == np.float64 else ""
+        df[cc].fillna(fill_value, inplace=True)
+    return df
+
+
+def _record_to_grid(start_m, end_m, template=None):
+    ii_start, ii_end = int(round(start_m)), int(round(end_m)) - 1
+    n_points = int(round(end_m))
+    grid = np.zeros(n_points) if template is None else np.copy(template)
+    grid[ii_start : (ii_end + 1)] = 1
+    return grid
+
+
+def _surface_records_to_grid(df):
+    n_points = int(round(df["end_m"].max()))
+    template = np.zeros(n_points)
+    return np.array(
+        [
+            surface_id * _record_to_grid(row.start_m, row.end_m, template=template)
+            for surface_id, row in df.iterrows()
+        ]
+    ).max(axis=0)
+
+
+def _extract_surface_records_from_grid(grid):
+    groups = (
+        (np.insert(np.diff(grid), 0, 1 if grid[0] > 0 else 0) != 0)
+        .astype(np.int)
+        .cumsum()
+    )
+    surfaces_dict = defaultdict(list)
+    for ii_group in set(groups):
+        ii_section = np.where(groups == ii_group)[0]
+        ii_start, ii_end = ii_section[0], ii_section[-1]
+        surface_id = grid[ii_start]
+        if surface_id == 0:
+            continue
+        surfaces_dict["surface_id"].append(surface_id)
+        surfaces_dict["start_m"].append(ii_start)
+        surfaces_dict["end_m"].append(ii_end + 1)
+    return pd.DataFrame(surfaces_dict)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,18 @@
+import pytest
+
+from pyramm.api import Connection
+
+
+@pytest.fixture
+def conn():
+    return Connection()
+
+
+@pytest.fixture
+def centreline(conn):
+    return conn.centreline()
+
+
+@pytest.fixture
+def top_surface(conn):
+    return conn.top_surface()

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -1,0 +1,246 @@
+import pytest
+import pandas as pd
+from datetime import date
+
+from pyramm.ops.top_surface import build_top_surface, append_surface_details_to_segments
+
+
+@pytest.fixture
+def original():
+    return pd.DataFrame.from_records(
+        [
+            {
+                "road_id": 100,
+                "start_m": 20,
+                "end_m": 200,
+                "surface_date": date(2020, 1, 1),
+                "name": "A",
+            },
+            {
+                "road_id": 100,
+                "start_m": 20,
+                "end_m": 60,
+                "surface_date": date(2020, 1, 1),
+                "name": "A",
+            },
+            {
+                "road_id": 101,
+                "start_m": 230,
+                "end_m": 500,
+                "surface_date": date(2021, 1, 1),
+                "name": "B",
+            },
+            {
+                "road_id": 101,
+                "start_m": 230,
+                "end_m": 260,
+                "surface_date": date(2021, 1, 1),
+                "name": "C",
+            },
+            {
+                "road_id": 102,
+                "start_m": 0,
+                "end_m": 9999,
+                "surface_date": date(2018, 6, 6),
+                "name": "D",
+            },
+        ]
+    ).set_index(["road_id", "start_m", "end_m"])
+
+
+class TestTopSurface:
+    class TestBuildTopSurface:
+        def test_build_top_surface(self, original):
+            index_names = ["road_id", "start_m", "end_m"]
+            custom = pd.DataFrame.from_records(
+                [
+                    {
+                        "road_id": 100,
+                        "start_m": 0,
+                        "end_m": 30,
+                        "surface_date": date(2020, 1, 2),
+                        "name": "1",
+                    },
+                    {
+                        "road_id": 100,
+                        "start_m": 20,
+                        "end_m": 30,
+                        "surface_date": date(2019, 12, 1),
+                        "name": "2",
+                    },
+                    {
+                        "road_id": 100,
+                        "start_m": 60,
+                        "end_m": 100,
+                        "surface_date": date(2020, 1, 5),
+                        "name": "3",
+                    },
+                    {
+                        "road_id": 100,
+                        "start_m": 190,
+                        "end_m": 220,
+                        "surface_date": date(2020, 1, 10),
+                        "name": "4",
+                    },
+                    {
+                        "road_id": 100,
+                        "start_m": 70,
+                        "end_m": 90,
+                        "surface_date": date(2020, 1, 5),
+                        "name": "5",
+                    },
+                ]
+            )
+            new = build_top_surface([original, custom])
+            expected = (
+                pd.DataFrame.from_records(
+                    [
+                        {
+                            "road_id": 100,
+                            "start_m": 0,
+                            "end_m": 30,
+                            "surface_date": date(2020, 1, 2),
+                            "name": "1",
+                        },
+                        {
+                            "road_id": 100,
+                            "start_m": 30,
+                            "end_m": 60,
+                            "surface_date": date(2020, 1, 1),
+                            "name": "A",
+                        },
+                        {
+                            "road_id": 100,
+                            "start_m": 60,
+                            "end_m": 70,
+                            "surface_date": date(2020, 1, 5),
+                            "name": "3",
+                        },
+                        {
+                            "road_id": 100,
+                            "start_m": 70,
+                            "end_m": 90,
+                            "surface_date": date(2020, 1, 5),
+                            "name": "5",
+                        },
+                        {
+                            "road_id": 100,
+                            "start_m": 90,
+                            "end_m": 100,
+                            "surface_date": date(2020, 1, 5),
+                            "name": "3",
+                        },
+                        {
+                            "road_id": 100,
+                            "start_m": 100,
+                            "end_m": 190,
+                            "surface_date": date(2020, 1, 1),
+                            "name": "A",
+                        },
+                        {
+                            "road_id": 100,
+                            "start_m": 190,
+                            "end_m": 220,
+                            "surface_date": date(2020, 1, 10),
+                            "name": "4",
+                        },
+                        {
+                            "road_id": 101,
+                            "start_m": 230,
+                            "end_m": 500,
+                            "surface_date": date(2021, 1, 1),
+                            "name": "B",
+                        },
+                        {
+                            "road_id": 102,
+                            "start_m": 0,
+                            "end_m": 9999,
+                            "surface_date": date(2018, 6, 6),
+                            "name": "D",
+                        },
+                    ]
+                )
+                .set_index(index_names)
+                .sort_index()
+            )
+            assert new.equals(expected)
+
+        def test_build_top_surface_real_table(self, top_surface):
+            top_surface_limited = top_surface.iloc[:1000]
+            new = build_top_surface([top_surface_limited])
+            expected = top_surface_limited.loc[
+                top_surface_limited["full_width_flag"].str.lower() == "y"
+            ]
+            assert new.equals(expected)
+
+    class TestAppendSurfaceDetailsToSegments:
+        def test_append_surface_details_to_segments(self, original):
+            df = pd.DataFrame.from_records(
+                [
+                    {"road_id": 99, "start_m": 0, "end_m": 20},
+                    {"road_id": 100, "start_m": 0, "end_m": 20},
+                    {"road_id": 100, "start_m": 20, "end_m": 40},
+                    {"road_id": 100, "start_m": 40, "end_m": 60},
+                    {"road_id": 101, "start_m": 200, "end_m": 220},
+                    {"road_id": 101, "start_m": 220, "end_m": 240},
+                    {"road_id": 101, "start_m": 240, "end_m": 260},
+                ]
+            )
+            original = build_top_surface(
+                [original]
+            )  # Removes overlapping surface records
+            df = append_surface_details_to_segments(df, original)
+            expected = df = pd.DataFrame.from_records(
+                [
+                    {
+                        "road_id": 99,
+                        "start_m": 0,
+                        "end_m": 20,
+                        "surface_date": "",
+                        "name": "",
+                    },
+                    {
+                        "road_id": 100,
+                        "start_m": 0,
+                        "end_m": 20,
+                        "surface_date": "",
+                        "name": "",
+                    },
+                    {
+                        "road_id": 100,
+                        "start_m": 20,
+                        "end_m": 40,
+                        "surface_date": date(2020, 1, 1),
+                        "name": "A",
+                    },
+                    {
+                        "road_id": 100,
+                        "start_m": 40,
+                        "end_m": 60,
+                        "surface_date": date(2020, 1, 1),
+                        "name": "A",
+                    },
+                    {
+                        "road_id": 101,
+                        "start_m": 200,
+                        "end_m": 220,
+                        "surface_date": "",
+                        "name": "",
+                    },
+                    {
+                        "road_id": 101,
+                        "start_m": 220,
+                        "end_m": 240,
+                        "surface_date": "",
+                        "name": "",
+                    },
+                    {
+                        "road_id": 101,
+                        "start_m": 240,
+                        "end_m": 260,
+                        "surface_date": date(2021, 1, 1),
+                        "name": "C",
+                    },
+                ]
+            )
+            assert df.equals(expected)

--- a/tests/test_pyramm.py
+++ b/tests/test_pyramm.py
@@ -1,25 +1,9 @@
-import pytest
 import pandas as pd
 from shapely.geometry.point import Point
 
 import pyramm
-from pyramm.api import parse_filters, Connection
+from pyramm.api import parse_filters
 from pyramm.geometry import Centreline
-
-
-@pytest.fixture
-def conn():
-    return Connection()
-
-
-@pytest.fixture
-def centreline(conn):
-    return conn.centreline()
-
-
-@pytest.fixture
-def top_surface(conn):
-    return conn.top_surface()
 
 
 def test_version():


### PR DESCRIPTION
- Allow importing of tables from csv using the read_csv() method.
- Function to generate a top_surface table containing non-overlapping surface records from serveral tables with overlapping surface records.
- Function to assign the correct top_surface row to smaller road segments by road_id, start_m and end_m.