### PR TITLE
version 1.6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pyramm"
-version = "1.5"
+version = "1.6"
 description = "Provides a wrapper to the RAMM API and additional tools for positional referencing"
 authors = ["John Bull"]
 homepage = "https://github.com/johnbullnz/pyramm"

--- a/pyramm/__init__.py
+++ b/pyramm/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.5"
+__version__ = "1.6"
 
 from . import api, ops  # noqa
 

--- a/pyramm/ops/top_surface.py
+++ b/pyramm/ops/top_surface.py
@@ -3,6 +3,8 @@ from typing import List
 import numpy as np
 import pandas as pd
 
+from pyramm.tables import TopSurface
+
 
 def build_top_surface(tables: List[pd.DataFrame]) -> pd.DataFrame:
     """
@@ -19,8 +21,9 @@ def build_top_surface(tables: List[pd.DataFrame]) -> pd.DataFrame:
     :return: new top_surface table with non-overlapping surface records.
 
     """
-    tables = [_limit_to_full_width(tt) for tt in tables]
+    tables = [TopSurface.from_frame(tt) for tt in tables]
     tables = [_reset_surface_table_index(tt) for tt in tables]
+    tables = [_limit_to_full_width(tt) for tt in tables]
 
     df = pd.concat(tables, ignore_index=True)
     top_surface = pd.DataFrame()
@@ -46,7 +49,9 @@ def append_surface_details_to_segments(df: pd.DataFrame, top_surface: pd.DataFra
     :return: Road segments with surfaces details appended.
 
     """
+    top_surface = TopSurface.from_frame(top_surface)
     top_surface = _reset_surface_table_index(top_surface)
+
     surface_columns = [
         cc for cc in top_surface.columns if cc not in ["road_id", "start_m", "end_m"]
     ]

--- a/pyramm/tables.py
+++ b/pyramm/tables.py
@@ -73,6 +73,7 @@ class CSurface(BaseTable):
 class TopSurface(BaseTable):
     table_name = "top_surface"
     index_name = ["road_id", "start_m", "end_m"]
+    date_columns = ["surface_date"]
 
 
 class SurfMaterial(BaseTable):

--- a/pyramm/tables.py
+++ b/pyramm/tables.py
@@ -4,6 +4,9 @@ from pyramm.helpers import _map_json
 from pyramm.geometry import transform, loads
 
 
+DEFAULT_DATE_COLUMNS = ["added_on", "chgd_on"]
+
+
 class BaseTable:
     table_name = None
     index_name = None
@@ -32,8 +35,12 @@ class BaseTable:
             self.df["geometry"] = [transform(loads(ww)) for ww in self.df["wkt"]]
 
     def _convert_dates(self):
-        for cc in self.date_columns:
-            self.df[cc] = to_datetime(self.df[cc])
+        date_columns = set(self.date_columns + DEFAULT_DATE_COLUMNS)
+        for cc in date_columns:
+            try:
+                self.df[cc] = to_datetime(self.df[cc])
+            except KeyError:
+                pass
 
     def _replace_nan(self):
         self.df = self.df.where(notnull(self.df), None)

--- a/pyramm/tables.py
+++ b/pyramm/tables.py
@@ -53,6 +53,16 @@ class BaseTable:
         new._replace_nan()
         return new.df
 
+    @classmethod
+    def from_frame(cls, df):
+        new = cls(None)
+        new.df = df.copy()
+        if new.df.index.names == [None]:
+            new.df.set_index(cls.index_name, drop=True, inplace=True)
+        new._convert_dates()
+        new._replace_nan()
+        return new.df
+
 
 class Roadnames(BaseTable):
     table_name = "roadnames"

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -1,5 +1,7 @@
 import pytest
 import pandas as pd
+
+from pandas import Timestamp
 from datetime import date
 
 from pyramm.ops.top_surface import build_top_surface, append_surface_details_to_segments
@@ -99,63 +101,63 @@ class TestTopSurface:
                             "road_id": 100,
                             "start_m": 0,
                             "end_m": 30,
-                            "surface_date": date(2020, 1, 2),
+                            "surface_date": Timestamp(2020, 1, 2),
                             "name": "1",
                         },
                         {
                             "road_id": 100,
                             "start_m": 30,
                             "end_m": 60,
-                            "surface_date": date(2020, 1, 1),
+                            "surface_date": Timestamp(2020, 1, 1),
                             "name": "A",
                         },
                         {
                             "road_id": 100,
                             "start_m": 60,
                             "end_m": 70,
-                            "surface_date": date(2020, 1, 5),
+                            "surface_date": Timestamp(2020, 1, 5),
                             "name": "3",
                         },
                         {
                             "road_id": 100,
                             "start_m": 70,
                             "end_m": 90,
-                            "surface_date": date(2020, 1, 5),
+                            "surface_date": Timestamp(2020, 1, 5),
                             "name": "5",
                         },
                         {
                             "road_id": 100,
                             "start_m": 90,
                             "end_m": 100,
-                            "surface_date": date(2020, 1, 5),
+                            "surface_date": Timestamp(2020, 1, 5),
                             "name": "3",
                         },
                         {
                             "road_id": 100,
                             "start_m": 100,
                             "end_m": 190,
-                            "surface_date": date(2020, 1, 1),
+                            "surface_date": Timestamp(2020, 1, 1),
                             "name": "A",
                         },
                         {
                             "road_id": 100,
                             "start_m": 190,
                             "end_m": 220,
-                            "surface_date": date(2020, 1, 10),
+                            "surface_date": Timestamp(2020, 1, 10),
                             "name": "4",
                         },
                         {
                             "road_id": 101,
                             "start_m": 230,
                             "end_m": 500,
-                            "surface_date": date(2021, 1, 1),
+                            "surface_date": Timestamp(2021, 1, 1),
                             "name": "B",
                         },
                         {
                             "road_id": 102,
                             "start_m": 0,
                             "end_m": 9999,
-                            "surface_date": date(2018, 6, 6),
+                            "surface_date": Timestamp(2018, 6, 6),
                             "name": "D",
                         },
                     ]
@@ -210,14 +212,14 @@ class TestTopSurface:
                         "road_id": 100,
                         "start_m": 20,
                         "end_m": 40,
-                        "surface_date": date(2020, 1, 1),
+                        "surface_date": Timestamp(2020, 1, 1),
                         "name": "A",
                     },
                     {
                         "road_id": 100,
                         "start_m": 40,
                         "end_m": 60,
-                        "surface_date": date(2020, 1, 1),
+                        "surface_date": Timestamp(2020, 1, 1),
                         "name": "A",
                     },
                     {
@@ -238,7 +240,7 @@ class TestTopSurface:
                         "road_id": 101,
                         "start_m": 240,
                         "end_m": 260,
-                        "surface_date": date(2021, 1, 1),
+                        "surface_date": Timestamp(2021, 1, 1),
                         "name": "C",
                     },
                 ]

--- a/tests/test_pyramm.py
+++ b/tests/test_pyramm.py
@@ -7,7 +7,7 @@ from pyramm.geometry import Centreline
 
 
 def test_version():
-    assert pyramm.__version__ == "1.5"
+    assert pyramm.__version__ == "1.6"
 
 
 def test_parse_filters():


### PR DESCRIPTION
- specify default datetime columns so that "added_on" and "chng_on" are automatically converted to timestamp columns.
- specify surface_date as a date column in the TopSurface class definition.
- add a from_frame method to the BaseTable class. The method converts datetime columns and sets the dataframe index as per the table definition. A step has been added to the top_surface ops functions to make sure the dataframe arguments are formated correctly.